### PR TITLE
plugin index: add ability to filter tags by regex

### DIFF
--- a/rfcs/0001-plugin-index.md
+++ b/rfcs/0001-plugin-index.md
@@ -60,7 +60,7 @@ Each Plugin has its own Manifest, which contains a map with the following conten
     - `commit`: Clones `update_url` as git repository and checks `branch` for new commits.
   - `update_url`: A valid URL complementing `type`. May be omitted, in which case `homepage` shall be used instead.
   - `branch`: Allows for special branches to be used when `type` is `commit`. If omitted, the default branch will be used instead.
-  - `regex`: If `type` is `tag`, only tags whose name matches this regular expression will be considered. May be omitted.
+  - `regex`: If `type` is `tag`, only tags whose name (fully or partially) matches this regular expression will be considered. Implementations should be PCRE2-compliant. May be omitted.
   - Any other key-value pairs will be interpreted as update keys:
     - They may contain `$version` as a substitution key
     - Upon detecting a new version, all occurences of `$version` will be replaced with the version detected using `type`.

--- a/rfcs/0001-plugin-index.md
+++ b/rfcs/0001-plugin-index.md
@@ -60,6 +60,7 @@ Each Plugin has its own Manifest, which contains a map with the following conten
     - `commit`: Clones `update_url` as git repository and checks `branch` for new commits.
   - `update_url`: A valid URL complementing `type`. May be omitted, in which case `homepage` shall be used instead.
   - `branch`: Allows for special branches to be used when `type` is `commit`. If omitted, the default branch will be used instead.
+  - `regex`: If `type` is `tag`, only tags whose name matches this regular expression will be considered. May be omitted.
   - Any other key-value pairs will be interpreted as update keys:
     - They may contain `$version` as a substitution key
     - Upon detecting a new version, all occurences of `$version` will be replaced with the version detected using `type`.


### PR DESCRIPTION
The plugin index has the ability to check repositories for new tags and update manifests based on the results. This causes problems for monorepos containing multiple plugins, each producing their own releases: All tags are considered for autoupdate, thus every new tag will trigger autoupdate for all manifests pointing at the repository.

This PR proposes an optional key `autoupdate.regex`, which the implementation shall use to filter the list of tags before determining if the manifest needs updating.

ref https://github.com/endless-sky/endless-sky-plugins/issues/1308 